### PR TITLE
ECU1370: set the serial console to ttymxc3

### DIFF
--- a/conf/machine/imx8mq-ecu1370.conf
+++ b/conf/machine/imx8mq-ecu1370.conf
@@ -42,7 +42,7 @@ UBOOT_DTB_NAME = "fsl-imx8mq-ecu1370.dtb"
 IMXBOOT_TARGETS = "flash_evk flash_evk_no_hdmi flash_dp_evk"
 IMX_BOOT_SOC_TARGET = "iMX8M"
 
-SERIAL_CONSOLES = "115200;ttymxc0"
+SERIAL_CONSOLES = "115200;ttymxc3"
 
 IMAGE_BOOTLOADER = "imx-boot"
 


### PR DESCRIPTION
The serial console is defined in the device tree to be ttymxc3, but the machine configuration uses ttymxc0. Turns out this creates an issue when this variable is used to let getty know where to start a userspace console, which is really ttymxc3.

On Yocto's core-image-minimal Getty starts from both ttymxc0 and ttymxc3, so this error was not noticed.

Changelog-entry: Fix: set ttymxc3 as the serial console.